### PR TITLE
use heroku app graphql schema

### DIFF
--- a/codegen.yml
+++ b/codegen.yml
@@ -1,4 +1,7 @@
-schema: http://localhost:8080/v1/graphql
+schema:
+  - http://smile-diary.herokuapp.com/v1/graphql:
+      headers:
+        "x-hasura-admin-secret": ${HASURA_GRAPHQL_ADMIN_SECRET}
 documents: ./**/*.graphql
 generates:
   ./graphql/api.ts:

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "codegen": "graphql-codegen --config codegen.yml",
     "dev": "next dev",
+    "prebuild": "yarn codegen",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",


### PR DESCRIPTION
Vercelでbuildするときにapi.tsがないことによってbuildがコケる
herokuにhostされているgraphql serverにschema問合せをしてcodegenするアレソレを


- herokuのhasuraにadmin 権限でアクセスするためにcodegen.ymlを変更
- codegen.ymlで参照するadminパスワードの環境変数をvercelにセット